### PR TITLE
Adding support for 'waiting until resource is ready' on create

### DIFF
--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -22,6 +22,8 @@ description: |-
 
 - **create_method** (String, Optional) Defaults to `create_method` set on the provider. Allows per-resource override of `create_method` (see `create_method` provider config documentation)
 - **create_path** (String, Optional) Defaults to `path`. The API path that represents where to CREATE (POST) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object if the data contains the `id_attribute`.
+- **create_ready_key** (String, Optional) The key to observe during resource creation. As long as its value is not equal to `create_ready_value` the resource is considered as pending. Similar to other configurable keys, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.
+- **create_ready_value** (String, Optional) The value at `create_ready_key` indicating that a resource has been successfully created.
 - **debug** (Boolean, Optional) Whether to emit verbose debug output while working with the API object on the server.
 - **destroy_method** (String, Optional) Defaults to `destroy_method` set on the provider. Allows per-resource override of `destroy_method` (see `destroy_method` provider config documentation)
 - **destroy_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.

--- a/fakeserver/fakeserver.go
+++ b/fakeserver/fakeserver.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -174,6 +175,15 @@ func (svr *Fakeserver) handleAPIObject(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	/* Simulating asynchronous endpoint */
+	if _, ok := obj["count_down"]; ok && r.Method == "GET" {
+		i, _ := strconv.Atoi(obj["count_down"].(string))
+		if i > 0 {
+			obj["count_down"] = strconv.Itoa(i - 1)
+		}
+	}
+
 	/* if data was sent, parse the data */
 	if string(b) != "" {
 		if svr.debug {

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -12,41 +12,45 @@ import (
 )
 
 type apiObjectOpts struct {
-	path          string
-	getPath       string
-	postPath      string
-	putPath       string
-	createMethod  string
-	readMethod    string
-	updateMethod  string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	id            string
-	idAttribute   string
-	data          string
+	path             string
+	getPath          string
+	postPath         string
+	putPath          string
+	createMethod     string
+	readMethod       string
+	updateMethod     string
+	destroyMethod    string
+	deletePath       string
+	searchPath       string
+	queryString      string
+	debug            bool
+	createReadyKey   string
+	createReadyValue string
+	readSearch       map[string]string
+	id               string
+	idAttribute      string
+	data             string
 }
 
 /*APIObject is the state holding struct for a restapi_object resource*/
 type APIObject struct {
-	apiClient     *APIClient
-	getPath       string
-	postPath      string
-	putPath       string
-	createMethod  string
-	readMethod    string
-	updateMethod  string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	id            string
-	idAttribute   string
+	apiClient        *APIClient
+	getPath          string
+	postPath         string
+	putPath          string
+	createMethod     string
+	readMethod       string
+	updateMethod     string
+	destroyMethod    string
+	deletePath       string
+	searchPath       string
+	queryString      string
+	debug            bool
+	createReadyKey   string
+	createReadyValue string
+	readSearch       map[string]string
+	id               string
+	idAttribute      string
 
 	/* Set internally */
 	data        map[string]interface{} /* Data as managed by the user */
@@ -99,23 +103,25 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:     iClient,
-		getPath:       opts.getPath,
-		postPath:      opts.postPath,
-		putPath:       opts.putPath,
-		createMethod:  opts.createMethod,
-		readMethod:    opts.readMethod,
-		updateMethod:  opts.updateMethod,
-		destroyMethod: opts.destroyMethod,
-		deletePath:    opts.deletePath,
-		searchPath:    opts.searchPath,
-		queryString:   opts.queryString,
-		debug:         opts.debug,
-		readSearch:    opts.readSearch,
-		id:            opts.id,
-		idAttribute:   opts.idAttribute,
-		data:          make(map[string]interface{}),
-		apiData:       make(map[string]interface{}),
+		apiClient:        iClient,
+		getPath:          opts.getPath,
+		postPath:         opts.postPath,
+		putPath:          opts.putPath,
+		createMethod:     opts.createMethod,
+		readMethod:       opts.readMethod,
+		updateMethod:     opts.updateMethod,
+		destroyMethod:    opts.destroyMethod,
+		deletePath:       opts.deletePath,
+		searchPath:       opts.searchPath,
+		queryString:      opts.queryString,
+		debug:            opts.debug,
+		createReadyKey:   opts.createReadyKey,
+		createReadyValue: opts.createReadyValue,
+		readSearch:       opts.readSearch,
+		id:               opts.id,
+		idAttribute:      opts.idAttribute,
+		data:             make(map[string]interface{}),
+		apiData:          make(map[string]interface{}),
 	}
 
 	if opts.data != "" {
@@ -167,6 +173,8 @@ func (obj *APIObject) toString() string {
 	buffer.WriteString(fmt.Sprintf("update_method: %s\n", obj.updateMethod))
 	buffer.WriteString(fmt.Sprintf("destroy_method: %s\n", obj.destroyMethod))
 	buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
+	buffer.WriteString(fmt.Sprintf("create_ready_key: %s\n", obj.createReadyKey))
+	buffer.WriteString(fmt.Sprintf("create_ready_value: %s\n", obj.createReadyValue))
 	buffer.WriteString(fmt.Sprintf("read_search: %s\n", spew.Sdump(obj.readSearch)))
 	buffer.WriteString(fmt.Sprintf("data: %s\n", spew.Sdump(obj.data)))
 	buffer.WriteString(fmt.Sprintf("api_data: %s\n", spew.Sdump(obj.apiData)))
@@ -285,7 +293,7 @@ func (obj *APIObject) readObject() error {
 
 	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), "")
 	if err != nil {
-		if strings.Contains(err.Error(), "Unexpected response code '404'") {
+		if strings.Contains(err.Error(), "unexpected response code '404'") {
 			log.Printf("api_object.go: 404 error while refreshing state for '%s' at path '%s'. Removing from state.", obj.id, obj.getPath)
 			obj.id = ""
 			return nil

--- a/restapi/resource_api_object_test.go
+++ b/restapi/resource_api_object_test.go
@@ -100,6 +100,24 @@ func TestAccRestApiObject_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("restapi_object.Bar", "api_data.config"),
 				),
 			},
+
+			{
+				Config: generateTestResource(
+					"WaitForReady",
+					`{ "id": "5678", "count_down": "4" }`,
+					map[string]interface{}{
+						"create_ready_key":   "count_down",
+						"create_ready_value": "0",
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.WaitForReady", "5678", client),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "id", "5678"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "api_data.count_down", "0"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "api_response", "{\"count_down\":\"0\",\"id\":\"5678\"}"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "create_response", "{\"count_down\":\"0\",\"id\":\"5678\"}"),
+				),
+			},
 		},
 	})
 


### PR DESCRIPTION
This adds a feature where the provider waits until a resource is ready. To determine that two new schema parameters were added:

* create_ready_key
* create_ready_value

After creating the resource and if set, the object is repeatedly read and validated using these two parameters. As soon as the value corresponds to the resource value at key the provider will deem the resource ready and continue execution.

The default timeout for checking readiness is 10 minutes. Use Terraform's 'timeouts' argument to override.

Issue: https://github.com/Mastercard/terraform-provider-restapi/issues/33