### PR TITLE
This adds a feature where the provider waits until a resource is read…

### DIFF
--- a/docs/resources/object.md
+++ b/docs/resources/object.md
@@ -26,6 +26,8 @@ description: |-
 - **destroy_data** (String, Optional) Valid JSON object to pass during to destroy requests.
 - **destroy_method** (String, Optional) Defaults to `destroy_method` set on the provider. Allows per-resource override of `destroy_method` (see `destroy_method` provider config documentation)
 - **destroy_path** (String, Optional) Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.
+- **create_ready_key** (String, Optional) The key to observe during resource creation. As long as its value is not equal to `create_ready_value` the resource is considered as pending. Similar to other configurable keys, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.
+- **create_ready_value** (String, Optional) The value at `create_ready_key` indicating that a resource has been successfully created.
 - **force_new** (List of String, Optional) Any changes to these values will result in recreating the resource instead of updating.
 - **id** (String, Optional) The ID of this resource.
 - **id_attribute** (String, Optional) Defaults to `id_attribute` set on the provider. Allows per-resource override of `id_attribute` (see `id_attribute` provider config documentation)

--- a/fakeserver/fakeserver.go
+++ b/fakeserver/fakeserver.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -174,6 +175,15 @@ func (svr *Fakeserver) handleAPIObject(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	/* Simulating asynchronous endpoint */
+	if _, ok := obj["count_down"]; ok && r.Method == "GET" {
+		i, _ := strconv.Atoi(obj["count_down"].(string))
+		if i > 0 {
+			obj["count_down"] = strconv.Itoa(i - 1)
+		}
+	}
+
 	/* if data was sent, parse the data */
 	if string(b) != "" {
 		if svr.debug {

--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -12,43 +12,47 @@ import (
 )
 
 type apiObjectOpts struct {
-	path          string
-	getPath       string
-	postPath      string
-	putPath       string
-	createMethod  string
-	readMethod    string
-	updateMethod  string
-	updateData    string
-	destroyMethod string
-	destroyData   string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	id            string
-	idAttribute   string
-	data          string
+	path             string
+	getPath          string
+	postPath         string
+	putPath          string
+	createMethod     string
+	readMethod       string
+	updateMethod     string
+	updateData       string
+	destroyMethod    string
+	destroyData      string
+	deletePath       string
+	searchPath       string
+	queryString      string
+	debug            bool
+	createReadyKey   string
+	createReadyValue string
+	readSearch       map[string]string
+	id               string
+	idAttribute      string
+	data             string
 }
 
 /*APIObject is the state holding struct for a restapi_object resource*/
 type APIObject struct {
-	apiClient     *APIClient
-	getPath       string
-	postPath      string
-	putPath       string
-	createMethod  string
-	readMethod    string
-	updateMethod  string
-	destroyMethod string
-	deletePath    string
-	searchPath    string
-	queryString   string
-	debug         bool
-	readSearch    map[string]string
-	id            string
-	idAttribute   string
+	apiClient        *APIClient
+	getPath          string
+	postPath         string
+	putPath          string
+	createMethod     string
+	readMethod       string
+	updateMethod     string
+	destroyMethod    string
+	deletePath       string
+	searchPath       string
+	queryString      string
+	debug            bool
+	createReadyKey   string
+	createReadyValue string
+	readSearch       map[string]string
+	id               string
+	idAttribute      string
 
 	/* Set internally */
 	data        map[string]interface{} /* Data as managed by the user */
@@ -108,25 +112,27 @@ func NewAPIObject(iClient *APIClient, opts *apiObjectOpts) (*APIObject, error) {
 	}
 
 	obj := APIObject{
-		apiClient:     iClient,
-		getPath:       opts.getPath,
-		postPath:      opts.postPath,
-		putPath:       opts.putPath,
-		createMethod:  opts.createMethod,
-		readMethod:    opts.readMethod,
-		updateMethod:  opts.updateMethod,
-		destroyMethod: opts.destroyMethod,
-		deletePath:    opts.deletePath,
-		searchPath:    opts.searchPath,
-		queryString:   opts.queryString,
-		debug:         opts.debug,
-		readSearch:    opts.readSearch,
-		id:            opts.id,
-		idAttribute:   opts.idAttribute,
-		data:          make(map[string]interface{}),
-		updateData:    make(map[string]interface{}),
-		destroyData:   make(map[string]interface{}),
-		apiData:       make(map[string]interface{}),
+		apiClient:        iClient,
+		getPath:          opts.getPath,
+		postPath:         opts.postPath,
+		putPath:          opts.putPath,
+		createMethod:     opts.createMethod,
+		readMethod:       opts.readMethod,
+		updateMethod:     opts.updateMethod,
+		destroyMethod:    opts.destroyMethod,
+		deletePath:       opts.deletePath,
+		searchPath:       opts.searchPath,
+		queryString:      opts.queryString,
+		debug:            opts.debug,
+		createReadyKey:   opts.createReadyKey,
+		createReadyValue: opts.createReadyValue,
+		readSearch:       opts.readSearch,
+		id:               opts.id,
+		idAttribute:      opts.idAttribute,
+		data:             make(map[string]interface{}),
+		updateData:       make(map[string]interface{}),
+		destroyData:      make(map[string]interface{}),
+		apiData:          make(map[string]interface{}),
 	}
 
 	if opts.data != "" {
@@ -200,6 +206,8 @@ func (obj *APIObject) toString() string {
 	buffer.WriteString(fmt.Sprintf("update_method: %s\n", obj.updateMethod))
 	buffer.WriteString(fmt.Sprintf("destroy_method: %s\n", obj.destroyMethod))
 	buffer.WriteString(fmt.Sprintf("debug: %t\n", obj.debug))
+	buffer.WriteString(fmt.Sprintf("create_ready_key: %s\n", obj.createReadyKey))
+	buffer.WriteString(fmt.Sprintf("create_ready_value: %s\n", obj.createReadyValue))
 	buffer.WriteString(fmt.Sprintf("read_search: %s\n", spew.Sdump(obj.readSearch)))
 	buffer.WriteString(fmt.Sprintf("data: %s\n", spew.Sdump(obj.data)))
 	buffer.WriteString(fmt.Sprintf("update_data: %s\n", spew.Sdump(obj.updateData)))

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -7,7 +7,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -104,6 +106,16 @@ func resourceRestAPI() *schema.Resource {
 				Description: "Whether to emit verbose debug output while working with the API object on the server.",
 				Optional:    true,
 			},
+			"create_ready_key": {
+				Type:        schema.TypeString,
+				Description: "The key to observe during resource creation. As long as its value is not equal to `create_ready_value` the resource is considered as pending. Similar to other configurable keys, the value may be in the format of 'field/field/field' to search for data deeper in the returned object.",
+				Optional:    true,
+			},
+			"create_ready_value": {
+				Type:        schema.TypeString,
+				Description: "The value at `create_ready_key` indicating that a resource has been successfully created.",
+				Optional:    true,
+			},
 			"read_search": {
 				Type:        schema.TypeMap,
 				Description: "Custom search for `read_path`. This map will take `search_key`, `search_value`, `results_key` and `query_string` (see datasource config documentation)",
@@ -177,14 +189,19 @@ func resourceRestAPI() *schema.Resource {
 				},
 			},
 		}, /* End schema */
-
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
-/* Since there is nothing in the ResourceData structure other
-   than the "id" passed on the command line, we have to use an opinionated
-   view of the API paths to figure out how to read that object
-   from the API */
+/*
+Since there is nothing in the ResourceData structure other
+
+	than the "id" passed on the command line, we have to use an opinionated
+	view of the API paths to figure out how to read that object
+	from the API
+*/
 func resourceRestAPIImport(d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
 	input := d.Id()
 
@@ -242,6 +259,36 @@ func resourceRestAPICreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("resource_api_object.go: Create routine called. Object built:\n%s\n", obj.toString())
 
 	err = obj.createObject()
+
+	if err != nil {
+		return nil
+	}
+
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		if obj.createReadyKey == "" || obj.createReadyValue == "" {
+			return nil
+		}
+
+		err = obj.readObject()
+		if err != nil {
+			return resource.NonRetryableError(err)
+		} else if obj.id == "" {
+			return resource.NonRetryableError(fmt.Errorf("cannot evaluate readiness unless the ID has been set"))
+		}
+
+		readyValue, err := GetObjectAtKey(obj.apiData, obj.createReadyKey, obj.debug)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if fmt.Sprint(readyValue) == obj.createReadyValue {
+			/* Resource is ready and we can exit the retry loop */
+			return nil
+		} else {
+			return resource.RetryableError(fmt.Errorf("resource not yet ready - current value: %s", readyValue))
+		}
+	})
+
 	if err == nil {
 		/* Setting terraform ID tells terraform the object was created or it exists */
 		d.SetId(obj.id)
@@ -337,10 +384,13 @@ func resourceRestAPIExists(d *schema.ResourceData, meta interface{}) (exists boo
 	return exists, err
 }
 
-/* Simple helper routine to build an api_object struct
-   for the various calls terraform will use. Unfortunately,
-   terraform cannot just reuse objects, so each CRUD operation
-   results in a new object created */
+/*
+Simple helper routine to build an api_object struct
+
+	for the various calls terraform will use. Unfortunately,
+	terraform cannot just reuse objects, so each CRUD operation
+	results in a new object created
+*/
 func makeAPIObject(d *schema.ResourceData, meta interface{}) (*APIObject, error) {
 	opts, err := buildAPIObjectOpts(d)
 	if err != nil {
@@ -414,6 +464,9 @@ func buildAPIObjectOpts(d *schema.ResourceData) (*apiObjectOpts, error) {
 	if v, ok := d.GetOk("query_string"); ok {
 		opts.queryString = v.(string)
 	}
+
+	opts.createReadyKey = d.Get("create_ready_key").(string)
+	opts.createReadyValue = d.Get("create_ready_value").(string)
 
 	readSearch := expandReadSearch(d.Get("read_search").(map[string]interface{}))
 	opts.readSearch = readSearch

--- a/restapi/resource_api_object_test.go
+++ b/restapi/resource_api_object_test.go
@@ -100,15 +100,35 @@ func TestAccRestApiObject_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("restapi_object.Bar", "api_data.config"),
 				),
 			},
+			{
+				Config: generateTestResource(
+					"WaitForReady",
+					`{ "id": "5678", "count_down": "4" }`,
+					map[string]interface{}{
+						"create_ready_key":   "count_down",
+						"create_ready_value": "0",
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRestapiObjectExists("restapi_object.WaitForReady", "5678", client),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "id", "5678"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "api_data.count_down", "0"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "api_response", "{\"count_down\":\"0\",\"id\":\"5678\"}"),
+					resource.TestCheckResourceAttr("restapi_object.WaitForReady", "create_response", "{\"count_down\":\"0\",\"id\":\"5678\"}"),
+				),
+			},
 		},
 	})
 
 	svr.Shutdown()
 }
 
-/* This function generates a terraform JSON configuration from
-   a name, JSON data and a list of params to set by coaxing it
-   all to maps and then serializing to JSON */
+/*
+This function generates a terraform JSON configuration from
+
+	a name, JSON data and a list of params to set by coaxing it
+	all to maps and then serializing to JSON
+*/
 func generateTestResource(name string, data string, params map[string]interface{}) string {
 	strData, _ := json.Marshal(data)
 	config := []string{


### PR DESCRIPTION
This adds a feature where the provider waits until a resource is ready. To determine that two new schema parameters were added:

create_ready_key
create_ready_value
After creating the resource and if set, the object is repeatedly read and validated using these two parameters. As soon as the value corresponds to the resource value at key the provider will deem the resource ready and continue execution.

The default timeout for checking readiness is 10 minutes. Use Terraform's 'timeouts' argument to override.

Issue: Mastercard#33